### PR TITLE
Respect LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all: $(SHARED_OBJ) $(STATIC_OBJ)
 
 #$(OBJ): $(SRC_DIR)/ignotum.c
 $(OBJDIR)/%.o: $(SRC_DIR)/%.c
-	$(CC) $(CFLAGS) -fPIC -c -o $@ $< -I.
+	$(CC) $(CFLAGS) $(LDFLAGS) -fPIC -c -o $@ $< -I.
 
 $(STATIC_OBJ): $(OBJS)
 	ar -cvr $(STATIC_OBJ) $(OBJS)


### PR DESCRIPTION
without it, mysql-magic compilation causes the following:
```
 * QA Notice: Files built without respecting LDFLAGS have been detected
 *  Please include the following list of files in your report:
 * /usr/bin/mysql-magic
```